### PR TITLE
Avoid deprecation warnings on pandas Series.fillna

### DIFF
--- a/finrl/meta/preprocessor/preprocessors.py
+++ b/finrl/meta/preprocessor/preprocessors.py
@@ -103,7 +103,7 @@ class FeatureEngineer:
             print("Successfully added user defined features")
 
         # fill the missing values at the beginning and the end
-        df = df.fillna(method="ffill").fillna(method="bfill")
+        df = df.ffill().bfill()
         return df
 
     def clean_data(self, data):


### PR DESCRIPTION
Series.fillna is deprecated starting from pandas 2.1.0 and the recommended solution is available since the minimum version supported.
Info on the deprecation on https://pandas.pydata.org/docs/reference/api/pandas.Series.fillna.html